### PR TITLE
docs: comment out badge with non working link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![GitHub release (latest by date)][github-release-badge]
 ![GitHub Repo stars][github-repo-stars-badge]
 ![GitHub][github-license-badge]
-[![Badge](<https://img.shields.io/badge/docs.bittu.eu.org%2Fdocs%2Fwinget--releaser--playground-abcdef?style=flat&logo=windowsterminal&label=Playground%20(dry-run)>)][playground-link]
+<!-- [![Badge](<https://img.shields.io/badge/docs.bittu.eu.org%2Fdocs%2Fwinget--releaser--playground-abcdef?style=flat&logo=windowsterminal&label=Playground%20(dry-run)>)][playground-link] -->
 
 Publish new releases of your application to the Windows Package Manager easily.
 


### PR DESCRIPTION
There was a badge for the playground, but it says DNS_PROBE_FINISHED_NXDOMAIN so it seems the domain does not exist anymore (or at least was not renewed).

### Pull Request Checklist

- [x] The commit message(s) follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.

### Changes & Notes
Minor change that comments out link to playground

Fixes #324.