### PR TITLE
fix: cargo command not found in `ubuntu-slim` runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ on:
     types: [released]
 jobs:
   publish:
-    runs-on: windows-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: vedantmgoyal9/winget-releaser@main
         with:
@@ -73,7 +73,7 @@ on:
     types: [released]
 jobs:
   publish:
-    runs-on: windows-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: vedantmgoyal9/winget-releaser@main
         with:
@@ -92,7 +92,7 @@ on:
     types: [released]
 jobs:
   publish:
-    runs-on: windows-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Publish X to WinGet
         uses: vedantmgoyal9/winget-releaser@main
@@ -118,7 +118,7 @@ on:
     types: [released]
 jobs:
   publish:
-    runs-on: windows-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Get version
         id: get-version

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
     - uses: cargo-bins/cargo-binstall@main
       env:
         GITHUB_TOKEN: ${{ github.token }}
-    - run: cargo binstall komac -y
+    - run: cargo-binstall komac -y
       env:
         GITHUB_TOKEN: ${{ github.token }}
       shell: pwsh


### PR DESCRIPTION
### Pull Request Checklist

- [x] The commit message(s) follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.

### Changes & Notes
GitHub's new [`ubuntu-slim`](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners) runners don't have Rust pre-installed so cargo-binstall can't be used as a cargo sub-command in these runners. I also updated the examples to use this new runner.